### PR TITLE
Add ebb_estimate

### DIFF
--- a/R/add_ebb_estimate.R
+++ b/R/add_ebb_estimate.R
@@ -1,0 +1,25 @@
+library(tidyverse)
+library(broom)
+source(file = "R/deconvolveR.R")
+
+add_ebb_estimate <- function(dat, total, x){
+  delta <- 0.01
+  df <- as.data.frame(list(n=dat$total,x=dat$x))
+  tau <- seq(from = 0.01, to = 0.99, by = delta)
+  result <- deconv(tau = tau, X = df, family = "Binomial", c0 = 1,pDegree = 5)
+  theta <- result$stats[, 'theta']
+  gTheta <- result$stats[, 'g']
+  f_alpha <- function(n_k, x_k) {
+    ## .01 is the delta_theta in the Riemann sum
+    sum(dbinom(x = x_k, size = n_k, prob = theta) * gTheta) * .01
+  }
+  
+  g_theta_hat <- function(n_k, x_k) {
+    gTheta * dbinom(x = x_k, size = n_k, prob = theta) / f_alpha(n_k, x_k)
+  }
+  col1 <- enquo(total)
+  col2 <- enquo(x)
+  dat %>%
+    rowwise() %>%
+    mutate(.fitted=sum(theta*g_theta_hat(x_k = !!col1, n_k = !!col2))*delta)
+}


### PR DESCRIPTION
I am not sure what your goals are with this package. 

I was thinking of adding wrapper functions that take advantage of the deconvolution backend while giving users a way to add g_theta estimates by piping. The inspiration is coming from [ebbr](https://github.com/dgrtwo/ebbr). I created a g-modeling version of `add_ebb_estimate`, but I think it would be cool to add `add_ebn_estimate` and `add_ebp_estimate` for the normal and Poisson cases as well. 

I would be happy to build a separate package off of a fork of this package if this is not the desired functionality you had in mind. 

Here is an example of `add_ebb_estimate`.

```{r}
library(deconvolveR)
library(tidyverse)
set.seed(2017)
obs <- 1000
source("R/add_ebb_estimate.R")
sim_dat <- data_frame(prob = rbeta(obs, 10, 40),
                  total = round(rlnorm(obs, 4, 2)) + 1,
                  x = rbinom(obs, total, prob))
sim_dat_eb <- sim_dat %>% add_ebb_estimate(x,total)
sim_dat_eb
```

Also, I do not expect you to actually pull this. I have not done any documentation work. This is just to see if you want your package to do this or if I should make a separate package for this.